### PR TITLE
Implement heart particles, repeat animations, vertical gallery, countdown

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -14,6 +14,7 @@
         "react-dom": "^18.2.0",
         "react-tsparticles": "^2.12.2",
         "tsparticles-engine": "^2.12.0",
+        "tsparticles-shape-heart": "^2.12.0",
         "tsparticles-slim": "^2.12.0"
       },
       "devDependencies": {
@@ -4574,6 +4575,30 @@
       "resolved": "https://registry.npmjs.org/tsparticles-shape-circle/-/tsparticles-shape-circle-2.12.0.tgz",
       "integrity": "sha512-L6OngbAlbadG7b783x16ns3+SZ7i0SSB66M8xGa5/k+YcY7zm8zG0uPt1Hd+xQDR2aNA3RngVM10O23/Lwk65Q==",
       "deprecated": "starting from tsparticles v3 the packages are now moved to @tsparticles/package-name instead of tsparticles-package-name",
+      "license": "MIT",
+      "dependencies": {
+        "tsparticles-engine": "^2.12.0"
+      }
+    },
+    "node_modules/tsparticles-shape-heart": {
+      "version": "2.12.0",
+      "resolved": "https://registry.npmjs.org/tsparticles-shape-heart/-/tsparticles-shape-heart-2.12.0.tgz",
+      "integrity": "sha512-OK8CJrCY0Z6YAedyfTQh52u7KsurkP8eLNWDW11BhqcvDQkfwJC5g25Y3VrcW9Rwc88hrbNwFQlsKbY6tOn7qA==",
+      "deprecated": "starting from tsparticles v3 the packages are now moved to @tsparticles/package-name instead of tsparticles-package-name",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/matteobruni"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/tsparticles"
+        },
+        {
+          "type": "buymeacoffee",
+          "url": "https://www.buymeacoffee.com/matteobruni"
+        }
+      ],
       "license": "MIT",
       "dependencies": {
         "tsparticles-engine": "^2.12.0"

--- a/package.json
+++ b/package.json
@@ -13,7 +13,8 @@
     "@jasperj1/pointer.js": "^1.0.3",
     "react-tsparticles": "^2.12.2",
     "tsparticles-engine": "^2.12.0",
-    "tsparticles-slim": "^2.12.0"
+    "tsparticles-slim": "^2.12.0",
+    "tsparticles-shape-heart": "^2.12.0"
   },
   "devDependencies": {
     "@types/react": "^18.0.0",

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -3,6 +3,7 @@ import Hero from './components/Hero';
 import Details from './components/Details';
 import Schedule from './components/Schedule';
 import Gallery from './components/Gallery';
+import Countdown from './components/Countdown';
 
 import CustomCursor from './components/CustomCursor';
 
@@ -19,6 +20,7 @@ const App: React.FC = () => {
       <ParticlesBackground />
       <Hero />
       <Details />
+      <Countdown />
       <Schedule />
       <Gallery />
     </>

--- a/src/components/Countdown.tsx
+++ b/src/components/Countdown.tsx
@@ -1,0 +1,44 @@
+import React, { useEffect, useState } from 'react';
+import '../styles/countdown.css';
+
+const targetDate = new Date('2025-08-05T00:00:00');
+
+const Countdown: React.FC = () => {
+  const [timeLeft, setTimeLeft] = useState<{days:number;hours:number;minutes:number}>({
+    days: 0,
+    hours: 0,
+    minutes: 0,
+  });
+
+  useEffect(() => {
+    const calc = () => {
+      const diff = targetDate.getTime() - new Date().getTime();
+      const d = Math.max(Math.floor(diff / (1000 * 60 * 60 * 24)), 0);
+      const h = Math.max(Math.floor(diff / (1000 * 60 * 60)) % 24, 0);
+      const m = Math.max(Math.floor(diff / (1000 * 60)) % 60, 0);
+      setTimeLeft({ days: d, hours: h, minutes: m });
+    };
+    calc();
+    const interval = setInterval(calc, 60000);
+    return () => clearInterval(interval);
+  }, []);
+
+  return (
+    <section className="countdown">
+      <div className="flip-unit">
+        <span className="number">{timeLeft.days}</span>
+        <span className="label">дней</span>
+      </div>
+      <div className="flip-unit">
+        <span className="number">{timeLeft.hours}</span>
+        <span className="label">часов</span>
+      </div>
+      <div className="flip-unit">
+        <span className="number">{timeLeft.minutes}</span>
+        <span className="label">минут</span>
+      </div>
+    </section>
+  );
+};
+
+export default Countdown;

--- a/src/components/Details.tsx
+++ b/src/components/Details.tsx
@@ -9,7 +9,7 @@ const Details: React.FC = () => (
     className="details"
     initial={{ opacity: 0, x: -100 }}
     whileInView={{ opacity: 1, x: 0 }}
-    viewport={{ once: true, amount: 0.2 }}
+    viewport={{ once: false, amount: 0.2 }}
   >
     <h2>Подробности</h2>
     <p>

--- a/src/components/Gallery.tsx
+++ b/src/components/Gallery.tsx
@@ -15,19 +15,20 @@ const Gallery: React.FC = () => (
     className="gallery"
     initial={{ opacity: 0, y: 100 }}
     whileInView={{ opacity: 1, y: 0 }}
-    viewport={{ once: true, amount: 0.2 }}
+    viewport={{ once: false, amount: 0.2 }}
   >
     <h2>Галерея</h2>
-    <div className="grid">
+    <div className="list">
       {images.map((src, idx) => (
-        <motion.img
+        <motion.div
           key={idx}
-          src={src}
-          alt={`gallery-${idx}`}
-          initial={{ opacity: 0 }}
-          whileInView={{ opacity: 1 }}
-          viewport={{ once: true }}
-        />
+          className={`item ${idx % 2 === 0 ? 'left' : 'right'}`}
+          initial={{ opacity: 0, x: idx % 2 === 0 ? -100 : 100 }}
+          whileInView={{ opacity: 1, x: 0 }}
+          viewport={{ once: false }}
+        >
+          <img src={src} alt={`gallery-${idx}`} />
+        </motion.div>
       ))}
     </div>
   </motion.section>

--- a/src/components/ParticlesBackground.tsx
+++ b/src/components/ParticlesBackground.tsx
@@ -2,10 +2,12 @@ import React, { useCallback } from 'react';
 import Particles from 'react-tsparticles';
 import type { Engine } from 'tsparticles-engine';
 import { loadSlim } from 'tsparticles-slim';
+import { loadHeartShape } from 'tsparticles-shape-heart';
 
 const ParticlesBackground: React.FC = () => {
   const particlesInit = useCallback(async (engine: Engine) => {
     await loadSlim(engine);
+    await loadHeartShape(engine);
   }, []);
 
   return (
@@ -26,6 +28,7 @@ const ParticlesBackground: React.FC = () => {
         },
         particles: {
           color: { value: '#2e2e2e' },
+          shape: { type: 'heart' },
           links: {
             color: '#2e2e2e',
             distance: 150,

--- a/src/components/Schedule.tsx
+++ b/src/components/Schedule.tsx
@@ -9,18 +9,18 @@ const Schedule: React.FC = () => (
     className="schedule"
     initial={{ opacity: 0, x: 100 }}
     whileInView={{ opacity: 1, x: 0 }}
-    viewport={{ once: true, amount: 0.2 }}
+    viewport={{ once: false, amount: 0.2 }}
   >
     <h2>Расписание дня</h2>
 
     <ul>
-      <motion.li initial={{ opacity: 0 }} whileInView={{ opacity: 1 }} viewport={{ once: true }}>
+      <motion.li initial={{ opacity: 0 }} whileInView={{ opacity: 1 }} viewport={{ once: false }}>
         15:00 - Регистрация брака
       </motion.li>
-      <motion.li initial={{ opacity: 0 }} whileInView={{ opacity: 1 }} viewport={{ once: true }}>
+      <motion.li initial={{ opacity: 0 }} whileInView={{ opacity: 1 }} viewport={{ once: false }}>
         17:00 - Фотосессия и приветственный фуршет
       </motion.li>
-      <motion.li initial={{ opacity: 0 }} whileInView={{ opacity: 1 }} viewport={{ once: true }}>
+      <motion.li initial={{ opacity: 0 }} whileInView={{ opacity: 1 }} viewport={{ once: false }}>
         18:00 - Банкет и развлекательная программа
       </motion.li>
     </ul>

--- a/src/styles/countdown.css
+++ b/src/styles/countdown.css
@@ -1,0 +1,26 @@
+.countdown {
+  padding: 4rem 2rem;
+  display: flex;
+  justify-content: center;
+  gap: 2rem;
+  color: #fff;
+}
+
+.flip-unit {
+  background-color: #333;
+  color: #fff;
+  padding: 1rem;
+  border-radius: 6px;
+  text-align: center;
+  min-width: 80px;
+  font-size: 2rem;
+  font-family: "Courier New", monospace;
+  box-shadow: 0 4px 8px rgba(0,0,0,0.3);
+}
+
+.flip-unit .label {
+  display: block;
+  margin-top: 0.5rem;
+  font-size: 0.75rem;
+  text-transform: uppercase;
+}

--- a/src/styles/gallery.css
+++ b/src/styles/gallery.css
@@ -5,15 +5,26 @@
   color: #fff;
 }
 
-.gallery .grid {
-  display: grid;
-  grid-template-columns: repeat(auto-fit, minmax(200px, 1fr));
-  gap: 1rem;
+.gallery .list {
+  display: flex;
+  flex-direction: column;
+  gap: 2rem;
   margin-top: 2rem;
 }
 
-.gallery img {
-  width: 100%;
-  display: block;
+.gallery .item {
+  display: flex;
+}
+
+.gallery .item.left {
+  justify-content: flex-start;
+}
+
+.gallery .item.right {
+  justify-content: flex-end;
+}
+
+.gallery .item img {
+  width: 300px;
   border-radius: 8px;
 }


### PR DESCRIPTION
## Summary
- make particles heart-shaped using tsparticles-shape-heart
- allow scroll animations to play every time in Details, Schedule and Gallery
- arrange gallery vertically with alternating left/right images
- add a flip-style countdown timer to the wedding date

## Testing
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_68585a597008832eb07ef804fcbccc1f