### PR TITLE
Customize cursor and countdown

### DIFF
--- a/src/components/CustomCursor.tsx
+++ b/src/components/CustomCursor.tsx
@@ -26,7 +26,8 @@ const CustomCursor = () => {
       mediaState: '-media',
       stateDetection: {
         '-pointer': 'a,button',
-        '-hidden': 'iframe'
+        '-hidden': 'iframe',
+        '-text': 'p,span,h1,h2,h3,h4,h5,h6,a,button,li,label,input,textarea'
       },
       visible: true,
       visibleOnState: false,

--- a/src/styles/countdown.css
+++ b/src/styles/countdown.css
@@ -3,4 +3,6 @@
   display: flex;
   justify-content: center;
   color: #fff;
+  --fcc-digit-color: red;
+  --fcc-background: beige;
 }

--- a/src/styles/cursor.css
+++ b/src/styles/cursor.css
@@ -1,4 +1,16 @@
 .mf-cursor {
+  color: transparent;
+  mix-blend-mode: normal;
+}
+
+.mf-cursor:before {
+  width: 100px;
+  height: 100px;
+  top: -50px;
+  left: -50px;
+}
+
+.mf-cursor.-text {
   color: #fff;
   mix-blend-mode: difference;
 }


### PR DESCRIPTION
## Summary
- enlarge custom cursor and show inversion only on text
- style countdown digits in red with beige frames

## Testing
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_685939657f2c832e98d748c02fb7ea39